### PR TITLE
Ignore hidden files in precompile and build commands (fix #4)

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -23,12 +23,14 @@ function createIndex() {
     var dirPath = rootify(dirName);
     var walker = walk(dirPath);
     walker.on('file', function(dir, stats, next) {
-      var path = unroot(dir + '/' + stats.name).replace(/\.js$/, '');
-      var name = inflector.objectify(path.replace(dirName, ''));
-      modules.push({
-        objectName: name,
-        path: path
-      });
+      if (stats.name.charAt(0) !== '.') {
+        var path = unroot(dir + '/' + stats.name).replace(/\.js$/, '');
+        var name = inflector.objectify(path.replace(dirName, ''));
+        modules.push({
+          objectName: name,
+          path: path
+        });
+      }
       next();
     });
   });

--- a/src/commands/precompile.js
+++ b/src/commands/precompile.js
@@ -41,12 +41,14 @@ function getTemplates(source, callback) {
   var walker = walk(source);
 
   walker.on('file', function(dir, stats, next) {
-    var path = dir + '/' + stats.name;
-    var name = path.replace(/\.handlebars$/, '').replace(source + '/', '');
-    templates.push({
-      name: name,
-      content: fs.readFileSync(path).toString()
-    });
+    if (stats.name.charAt(0) !== '.') {
+      var path = dir + '/' + stats.name;
+      var name = path.replace(/\.handlebars$/, '').replace(source + '/', '');
+      templates.push({
+        name: name,
+        content: fs.readFileSync(path).toString()
+      });
+    }
     next();
   });
 


### PR DESCRIPTION
Hi @rpflorence,

here’s my fix for skipping hidden files.

I didn’t add tests since I didn’t know what strategy you would like to take for this.

I thought I could create a fake hidden file in build.js in the `create` function so that after building `assertFilesMatch('index.js');` would catch any errors.

Let me know what you think!
