### PR TITLE
Target multiple Ember apps from `.ember` config file. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 npm-debug.log
-
+.DS_Store

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -10,7 +10,7 @@ var precompile = require('./precompile');
 var root;
 
 module.exports = function(program) {
-  root = require('../util/config')().appDir;
+  root = require('../util/config')(program).appDir;
   precompile(rootify('templates'), rootify('templates.js'), function() {
     createIndex().then(build);
   });

--- a/src/templates/create/ember.handlebars
+++ b/src/templates/create/ember.handlebars
@@ -1,5 +1,7 @@
 {
-  "modules": "{{modules}}",
-  "appDir": "{{appDir}}"
+  "{{appDir}}": {
+    "modules": "{{modules}}",
+    "appDir": "{{appDir}}"
+  }
 }
 

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -1,13 +1,22 @@
 var fs = require('fs');
 var message = require('./message');
 
-module.exports = function() {
+module.exports = function(program) {
+  var program = program || {};
   if (fs.existsSync('.ember')) {
-    return JSON.parse(fs.readFileSync('.ember'));
+    var data = JSON.parse(fs.readFileSync('.ember'));
+    console.log(data);
+    if (program.args && program.args.length === 2) {
+      var app = program.args[1];
+      return data[app];
+    } else {
+      for (var key in data) {
+        return data[key]
+      }
+    }
   } else {
     message.notify("ember: could not find .ember file, please run `ember create [appDir]`");
     process.exit();
     return 'shutup jslint';
   }
 };
-

--- a/test/build.js
+++ b/test/build.js
@@ -13,9 +13,28 @@ function create(done) {
   });
 }
 
+function createAnother(done) {
+  exec("./bin/ember create another-test-app", function(err) {
+    if (err) throw new Error(err);
+    fs.writeFile('.ember', '{\n  "test-app": {\n    "modules": "cjs",\n    "appDir": "test-app"\n  },\n  "another-test-app": {\n    "modules": "cjs",\n    "appDir": "another-test-app"\n  }\n}', function(err) {
+      if (err) throw new Error(err);
+      done();
+    });
+  });
+}
+
 function cleanup(done) {
   rm("./test-app", function() {
     fs.unlink('.ember', done);
+  });
+}
+
+function cleanupAnother(done) {
+  rm("./another-test-app", function() {
+    fs.writeFile('.ember', '{\n  "modules": "cjs",\n   "appDir": "test-app"\n}', function(err) {
+      if (err) throw new Error(err)
+      done();
+    });
   });
 }
 
@@ -75,5 +94,22 @@ describe("build", function() {
     });
   });
 
+  describe("targets specific project by key in .ember config file", function() {
+
+    before(createAnother);
+
+    after(cleanupAnother);
+
+    it("should build the correct app", function(done) {
+      exec("./bin/ember build another-test-app", function(err) {
+        if (err) throw new Error(err);
+        fs.exists("./another-test-app/application.js", function(exists) {
+          exists.should.equal(true);
+          done();
+        });
+      });
+    });
+
+  });
 });
 


### PR DESCRIPTION
Basically I have a rails app with multiple Ember applications that I use ember-tools with. I wanted to be able to declare multiple apps in the `.ember` and target them specifically with `ember build specific-app`. 

Here is an example of a new .ember file:

``` JSON
{
  "test-app": {
    "modules": "cjs",
    "appDir": "test-app"
  },
  "another-test-app": {
    "modules": "cjs",
    "appDir": "another-test-app"
  }
}
```

Running `ember build` will run the first app in the file, or you can target by using the App name. I incorporate this into my Grunt.js workflow and find it helpful.

Test added that passes.
