### PR TITLE
follow symlinks in source tree when building

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -53,7 +53,7 @@ function createIndex() {
 
 function build() {
   var command = __dirname + '/../../node_modules/browserbuild/bin/browserbuild ' +
-                "-m index -b " + root + "/ `find "+ root + " -name '*.js'` > " +
+                "-m index -b " + root + "/ `find -L "+ root + " -name '*.js'` > " +
                 rootify('application.js');
   exec(command, function (error, stdout, stderr) {
     message.fileCreated(rootify('application.js'));


### PR DESCRIPTION
by default the `find` command does not descend into symlinked
directories. if you want to symlink some external directory into your
source tree to be included in the build, the -L option to the `find`
command is necessary.
