### PR TITLE
Use short HTML5 charset declaration.

### DIFF
--- a/src/templates/create/index.html.hbs
+++ b/src/templates/create/index.html.hbs
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-	<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+	<meta charset="utf-8">
 	<title>Ember App</title>
 </head>
 <body>


### PR DESCRIPTION
This switches the longer content-type meta tag for the shorter HTML5 equivalent.
