### PR TITLE
move 'mixins' to the top of the appDirs list, so that mixin definitions ...

### DIFF
--- a/src/util/appDirs.js
+++ b/src/util/appDirs.js
@@ -1,4 +1,5 @@
 module.exports = [
+  'mixins',
   'components',
   'config',
   'controllers',
@@ -6,7 +7,6 @@ module.exports = [
   'models',
   'routes',
   'templates',
-  'views',
-  'mixins'
+  'views'
 ];
 


### PR DESCRIPTION
...are available for use by models, controllers, views, etc.
