### PR TITLE
`ember build` should ignore backup files

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -58,7 +58,7 @@ function createIndex(cb) {
     var dirPath = getAssetPath(dirName);
     var walker = walk(dirPath);
     walker.on('file', function(dir, stats, next) {
-      if (stats.name.charAt(0) !== '.') {
+      if (stats.name.charAt(0) !== '.' && stats.name.match(/\.js$/)) {
         var path = unroot(dir+'/'+stats.name).replace(/\.js$/, '');
         if (dirName == 'helpers') {
           helpers.push({path: path});


### PR DESCRIPTION
When editing a file in Vim, it creates backup files which end with a `~`.

`ember build` picks up these files, instead of only reading files that end with `.js`:

```
Error: Parsing file /app/js/index.js: Line 10: Unexpected token ~

/Users/User/git/ember-tools/src/commands/build.js:104
    if (error && !env.watch) throw new Error(error);
                                   ^
Error: Error: Command failed: Error: Parsing file /app/js/index.js: Line 10: Unexpected token ~

    at /Users/User/git/ember-tools/src/commands/build.js:104:36
    at ChildProcess.exithandler (child_process.js:641:7)
    at ChildProcess.EventEmitter.emit (events.js:98:17)
    at maybeClose (child_process.js:735:16)
    at Socket.<anonymous> (child_process.js:948:11)
    at Socket.EventEmitter.emit (events.js:95:17)
    at Pipe.close (net.js:466:12)
```

The generated `index.js` file looks like this:

``` js
// This file is auto-generated by `ember build`.
// You should not modify it.

var App = window.App = require('./config/app');
require('./templates');


App.AuthorizeIndexController = require('./controllers/authorize_index_controller');
App.AuthorizeIndexController.js~ = require('./controllers/authorize_index_controller.js~');

require('./config/routes');

module.exports = App;
```

The attached patch fixes it.
