### PR TITLE
Update build.js

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -87,7 +87,8 @@ function build(env, cb) {
   var outFile = (env.outFile || getAssetPath('application.js'));
   var outDir = path.dirname(outFile);
   var command = [
-    'node', __dirname + '/../../node_modules/browserify/bin/cmd',
+    'node',
+    '"'+__dirname + '/../../node_modules/browserify/bin/cmd"',
     '--noparse='+root+'/vendor/ember.js',
     '--noparse='+root+'/vendor/jquery.js',
     '--noparse='+root+'/vendor/ember-data.js',


### PR DESCRIPTION
Unable to build On Windows 7, if user have a space in his profile name. Ex : C:\Users\my name\AppData\Roaming\npm\node_modules\ember-tools
The build throw an error because the command path is broken.
I have simply added double quote around the path so the command work properly.
