### PR TITLE
Added server command to ./bin/ember

### DIFF
--- a/bin/ember
+++ b/bin/ember
@@ -5,10 +5,11 @@ var build = require('../src/commands/build');
 var generate = require('../src/commands/generate');
 var update = require('../src/commands/update');
 var precompile = require('../src/commands/precompile');
+var server = require('../src/commands/server');
 var message = require('../src/util/message');
 
 program
-  .version('0.2.7')
+  .version('0.2.8')
   .usage("[command] [options]\n\n  Command-Specific Help\n\n    ember [command] --help");
 
 program
@@ -65,6 +66,11 @@ program
                  "stable.\n" +
                  "\t\t\t   Default version is stable.\n")
   .action(update);
+
+program
+  .command('server')
+  .description('creates a basic server to serve Ember files')
+  .action(server)
 
 program.parse(process.argv);
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "glob": "3.2.1",
     "request": "~2.21.0",
     "fsmonitor": "~0.2.2",
-    "pathspec": "~0.9.2"
+    "pathspec": "~0.9.2",
+    "connect": "~2.12.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/src/commands/server.js
+++ b/src/commands/server.js
@@ -1,0 +1,9 @@
+var util = require('util'),
+    connect = require('connect'),
+    port = 3000;
+
+module.exports = function() {
+    connect.createServer(connect.static(process.cwd())).listen(port);
+    util.puts('Listening on ' + port + '...');
+    util.puts('Press Ctrl + C to stop.');    
+}

--- a/test/integration/server.spec.js
+++ b/test/integration/server.spec.js
@@ -1,0 +1,13 @@
+/*var exec = require("child_process").exec;
+
+//the below won't succeed because it needs to hear a "listening" event from connect
+//if anyone knows how to do this, this test can be completed.
+
+describe("server", function() {
+  it("should start successfully", function(done) {
+    exec('./bin/ember server', function(err) {
+      if(err) throw err;
+      done();
+    });
+  });
+});*/


### PR DESCRIPTION
I'm using pushState with my Ember app, and came in handy to just have a basic server available in order to serve clean URLs, so I've added a rudimentary implementation. Not sure if this is something that people would find useful, but thought I'd throw it into the mix and have a discussion.

Testing wise, not sure what would be beneficial, I was going to just have an initial test to see whether it started successfully, but having issues detecting a "listening" event once connect has created the connection. If anyone wants to take a look and make suggestions, I'd be grateful.

Feedback?
